### PR TITLE
Fix meta description tag on docs pages

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6,9 +6,9 @@
     <meta property="og:title" content="Polygon.io Docs" />
     <meta property="og:url" content="https://polygon.io" />
     <meta property="og:type" content="website" />
-    <meta property="og:description" content="desc" />
+    <meta property="og:description" content="Create your application in any language you desire. No more C++/Java limitations. Use the technology you already know and spend your time creating, not integrating." />
     <meta property="og:image" content="https://polygon.io/images/splash.jpg" />
-    <meta name="description" content="desc" />
+    <meta name="description" content="Create your application in any language you desire. No more C++/Java limitations. Use the technology you already know and spend your time creating, not integrating." />
     <meta
       name="keywords"
       content="realtime,streaming,stocks,equities,forex,currencies,crypto,api,data"


### PR DESCRIPTION
Fixes:
<img width="512" alt="Screen Shot 2020-06-02 at 11 12 26 AM" src="https://user-images.githubusercontent.com/64220601/83537023-056f1c80-a4c2-11ea-90e5-f31ce79f063f.png">
