### PR TITLE
Fix typo (retreive -> retrieve)

### DIFF
--- a/app/swagger/41_stocks.yaml
+++ b/app/swagger/41_stocks.yaml
@@ -291,7 +291,7 @@
   #       default: AAPL
   #     - name: date
   #       in: path
-  #       description: Date/Day of the historic ticks to retreive
+  #       description: Date/Day of the historic ticks to retrieve
   #       required: true
   #       type: string
   #       format: date
@@ -369,7 +369,7 @@
         default: AAPL
       - name: date
         in: path
-        description: Date/Day of the historic ticks to retreive ( YYYY-MM-DD )
+        description: Date/Day of the historic ticks to retrieve ( YYYY-MM-DD )
         required: true
         type: string
         format: date
@@ -447,7 +447,7 @@
   #       default: AAPL
   #     - name: date
   #       in: path
-  #       description: Date/Day of the historic ticks to retreive
+  #       description: Date/Day of the historic ticks to retrieve
   #       required: true
   #       type: string
   #       format: date
@@ -527,7 +527,7 @@
         default: AAPL
       - name: date
         in: path
-        description: Date/Day of the historic ticks to retreive ( YYYY-MM-DD )
+        description: Date/Day of the historic ticks to retrieve ( YYYY-MM-DD )
         required: true
         type: string
         format: date

--- a/app/swagger/42_forex.yaml
+++ b/app/swagger/42_forex.yaml
@@ -5,7 +5,7 @@
     get:
       summary: Historic Forex Ticks
       description: |
-        Get historic ticks for a currency pair. Example for **USD/JPY** the from would be **USD** and to would be **JPY**. The date formatted like **2017-6-22**
+        Get historic ticks for a currency pair. Example for **USD/JPY** thefrom would be **USD** and to would be **JPY**. The date formatted like **2017-6-22**
       tags:
         - Forex / Currencies
       parameters: 
@@ -23,7 +23,7 @@
         default: USD
       - name: date
         in: path
-        description: Date/Day of the historic ticks to retreive
+        description: Date/Day of the historic ticks to retrieve
         required: true
         type: string
         format: date

--- a/app/swagger/4_crypto.yaml
+++ b/app/swagger/4_crypto.yaml
@@ -185,7 +185,7 @@
         default: USD
       - name: date
         in: path
-        description: Date/Day of the historic ticks to retreive
+        description: Date/Day of the historic ticks to retrieve
         required: true
         type: string
         format: date


### PR DESCRIPTION
just a quick fix replacing 'retreive' with 'retrieve'.