### PR TITLE
Specify some ints as double precision formats.

### DIFF
--- a/app/helpers/icons.js
+++ b/app/helpers/icons.js
@@ -1,18 +1,18 @@
 // Font Awesome:
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 // SOLID
-import { faTimes } from "@fortawesome/free-solid-svg-icons";
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
 library.add(faTimes);
 
 // BRANDS
-import { faGithub } from "@fortawesome/free-brands-svg-icons";
+import { faGithub } from '@fortawesome/free-brands-svg-icons';
 library.add(faGithub);
 
 // REGULAR
-import { faCheckCircle } from "@fortawesome/free-regular-svg-icons";
+import { faCheckCircle } from '@fortawesome/free-regular-svg-icons';
 library.add(faCheckCircle);
 
 export default library;

--- a/app/swagger/1_definitions.yaml
+++ b/app/swagger/1_definitions.yaml
@@ -169,18 +169,22 @@ definitions:
     properties:
       o:
         type: integer
+        format: double
         example: 173.15
         description: Open price
       c:
         type: integer
+        format: double
         example: 173.20
         description: Close price
       l:
         type: integer
+        format: double
         example: 173.15
         description: Low price
       h:
         type: integer
+        format: double
         example: 173.21
         description: High price
       v:
@@ -461,12 +465,15 @@ definitions:
         example: "2017-12-31T00:00:00.000Z"
       actualEPS:
         type: number
+        format: double
         example: 3.89
       consensusEPS:
         type: number
+        format: double
         example: 3.82
       estimatedEPS:
         type: number
+        format: double
         example: 3.82
       announceTime:
         type: string
@@ -476,15 +483,19 @@ definitions:
         example: 9
       EPSSurpriseDollar:
         type: number
+        format: double
         example: 0.07
       yearAgo:
         type: number
+        format: double
         example: 3.36
       yearAgoChangePercent:
         type: number
+        format: double
         example: 16
       estimatedChangePercent:
         type: number
+        format: double
         example: 14
 
   Financial:
@@ -756,6 +767,7 @@ definitions:
         description: Number of analysts reporting
       change:
         type: number
+        format: double
         example: -0.04
         description: Change from last month to current
       strongBuy:

--- a/app/swagger/1_definitions_crypto.yaml
+++ b/app/swagger/1_definitions_crypto.yaml
@@ -9,10 +9,12 @@
     properties:
       price:
         type: integer
+        format: double
         example: 9349.44
         description: Trade Price
       size:
         type: integer
+        format: double
         example: 0.03
         description: Size of the trade
       exchange:
@@ -38,10 +40,12 @@
     properties:
       p:
         type: integer
+        format: double
         example: 9349.44
         description: Trade Price
       s:
         type: integer
+        format: double
         example: 0.03
         description: Size of the trade
       x:
@@ -113,10 +117,12 @@
         $ref: "#/definitions/CryptoSnapshotAgg"
       todaysChange:
         type: integer
+        format: double
         example: .001
         description: Value of the change from previous day
       todaysChangePerc:
         type: integer
+        format: double
         example: 2.55
         description: Percentage change since previous day
       updated:
@@ -133,6 +139,7 @@
     properties:
       p:
         type: integer
+        format: double
         example: 0.2907
         description: Price of this book level
       x:
@@ -165,14 +172,17 @@
           $ref: "#/definitions/CryptoSnapshotBookItem"
       bidCount:
         type: integer
+        format: double
         example: 1242.001
         description: Combined total number of bids in the book
       askCount:
         type: integer
+        format: double
         example: 1242.001
         description: Combined total number of asks in the book
       spread:
         type: integer
+        format: double
         example: .001
         description: Difference between the best bid and the best ask price accross exchanges
       updated:
@@ -190,22 +200,27 @@
     properties:
       c:
         type: integer
+        format: double
         example: 0.2907
         description: Close price
       h:
         type: integer
+        format: double
         example: 0.2947
         description: High price
       l:
         type: integer
+        format: double
         example: 0.2901
         description: Low price
       o:
         type: integer
+        format: double
         example: 0.2905
         description: Open price
       v:
         type: integer
+        format: double
         example: 1432.2907
         description: Volume
 

--- a/app/swagger/1_definitions_forex.yaml
+++ b/app/swagger/1_definitions_forex.yaml
@@ -6,10 +6,12 @@
     properties:
       a:
         type: integer
+        format: double
         example: 0.80392
         description: Ask price
       b:
         type: integer
+        format: double
         example: 0.80392
         description: Bid price
       t:
@@ -26,6 +28,7 @@
       price:
         type: integer
         example: 0.78131
+        format: double
         description: Price of the trade
         format: double
       exchange:
@@ -67,18 +70,22 @@
     properties:
       o:
         type: integer
+        format: double
         example: 0.81151
         description: Open price
       c:
         type: integer
+        format: double
         example: 0.81287
         description: Close price
       l:
         type: integer
+        format: double
         example: 0.81
         description: Low price
       h:
         type: integer
+        format: double
         example: 0.8141
         description: High price
       v:
@@ -111,10 +118,12 @@
         $ref: "#/definitions/ForexSnapshotAgg"
       todaysChange:
         type: integer
+        format: double
         example: .001
         description: Value of the change from previous day
       todaysChangePerc:
         type: integer
+        format: double
         example: 2.55
         description: Percentage change since previous day
       updated:
@@ -132,18 +141,22 @@
     properties:
       c:
         type: integer
+        format: double
         example: 0.2907
         description: Close price
       h:
         type: integer
+        format: double
         example: 0.2947
         description: High price
       l:
         type: integer
+        format: double
         example: 0.2901
         description: Low price
       o:
         type: integer
+        format: double
         example: 0.2905
         description: Open price
       v:

--- a/app/swagger/1_definitions_stocks.yaml
+++ b/app/swagger/1_definitions_stocks.yaml
@@ -69,10 +69,12 @@
         $ref: "#/definitions/StocksSnapshotAgg"
       todaysChange:
         type: integer
+        format: double
         example: .001
         description: Value of the change from previous day
       todaysChangePerc:
         type: integer
+        format: double
         example: 2.55
         description: Percentage change since previous day
       updated:
@@ -89,6 +91,7 @@
     properties:
       p:
         type: integer
+        format: double
         example: 0.2907
         description: Price of this book level
       x:
@@ -119,18 +122,22 @@
         description: Ticker symbol requested
       open:
         type: integer
+        format: double
         example: 352.89
         description: Official open price
       high:
         type: integer
+        format: double
         example: 352.89
         description: Official high price
       low:
         type: integer
+        format: double
         example: 352.89
         description: Official low price
       close:
         type: integer
+        format: double
         example: 352.89
         description: Official close price
       volume:
@@ -143,6 +150,7 @@
         description: Open price in pre-market trading
       afterHours:
         type: integer
+        format: double
         example: 350.24
         description: Close price after hours trading
 
@@ -170,14 +178,17 @@
           $ref: "#/definitions/StocksSnapshotBookItem"
       bidCount:
         type: integer
+        format: double
         example: 1242.001
         description: Combined total number of bids in the book
       askCount:
         type: integer
+        format: double
         example: 1242.001
         description: Combined total number of asks in the book
       spread:
         type: integer
+        format: double
         example: .001
         description: Difference between the best bid and the best ask price accross exchanges
       updated:
@@ -233,6 +244,7 @@
           example: 14
       p:
         type: integer
+        format: double
         example: 223.001
         description: Price of the trade
       z:
@@ -285,6 +297,7 @@
       
       p:
         type: integer
+        format: double
         example: 223.001
         description: BID Price
       x:
@@ -298,6 +311,7 @@
       
       P:
         type: integer
+        format: double
         example: 223.001
         description: ASK Price
       X:
@@ -326,23 +340,27 @@
     properties:
       c:
         type: integer
+        format: double
         example: 0.2907
         description: Close price
       h:
         type: integer
+        format: double
         example: 0.2947
         description: High price
       l:
         type: integer
+        format: double
         example: 0.2901
         description: Low price
       o:
         type: integer
+        format: double
         example: 0.2905
         description: Open price
       v:
         type: integer
-        example: 1432.2907
+        example: 1432
         description: Volume
 
 
@@ -353,6 +371,7 @@
     properties:
       p:
         type: integer
+        format: double
         example: 120.00
         description: Bid Price
       s:
@@ -361,6 +380,7 @@
         description: Bid size in lots
       P:
         type: integer
+        format: double
         example: 121.00
         description: Ask Price
       S:
@@ -388,18 +408,22 @@
         example: 31315282
       o:
         type: integer
+        format: double
         description: Open
         example: 102.87
       c:
         type: integer
+        format: double
         description: Close
         example: 103.74
       h:
         type: integer
+        format: double
         description: High
         example: 103.82
       l:
         type: integer
+        format: double
         description: Low
         example: 102.65
       t:

--- a/app/swagger/42_forex.yaml
+++ b/app/swagger/42_forex.yaml
@@ -137,10 +137,12 @@
                 description: To currency symbol
               initialAmount:
                 type: number
+                format: double
                 example: 100.00
                 description: The amount we are to convert
               converted:
                 type: number
+                format: double
                 example: 78.76
                 description: To currency symbol
               lastTrade:

--- a/app/swagger/4_crypto.yaml
+++ b/app/swagger/4_crypto.yaml
@@ -80,6 +80,7 @@
                 properties:
                   avg:
                     type: int
+                    format: double
                     description: Average of the trades analyzed
                     example: 9348.727
                   tradesAveraged:
@@ -141,10 +142,12 @@
                 example: 2018-5-9
               open:
                 type: int
+                format: double
                 description: Opening trade price
                 example: 9228.1801
               close:
                 type: int
+                format: double
                 description: Closing trade price
                 example: 9300.40000001
               openTrades:


### PR DESCRIPTION
Some of the prices in the docs were specified as `int` only. This updates them to specify that they are double(float64) precision.

However, I did notice that the UI does not seem to make any visible changes when rendered. I filed an issue for this here https://github.com/polygon-io/ui-swagger/issues/72

