### PR TITLE
Add string item type to v2 ref markets, locales

### DIFF
--- a/app/swagger/3_reference.yaml
+++ b/app/swagger/3_reference.yaml
@@ -270,6 +270,8 @@
                     desc: Indices
                   - market: MF
                     desc: Mutual Funds
+                items:
+                  type: string
         401:
           $ref: '#/definitions/Unauthorized'
         404:
@@ -305,6 +307,8 @@
                     name: Great Britain / UK
                   - locale: CA
                     name: Canada
+                items:
+                  type: string
         401:
           $ref: '#/definitions/Unauthorized'
         404:


### PR DESCRIPTION
As part of the polygon rust integration that I am current developing (https://github.com/19h/polygon-rs) the REST client-code is generated from the swagger json file (https://polygon.io/docs/swagger.json) using a custom code generator for Rust (https://github.com/19h/rust-swagger-codegen_v3) built against swagger-codegen v3 (https://github.com/swagger-api/swagger-codegen/tree/3.0.0).

The specification of the v2-reference markets / locales interfaces lacks a string type definition as it's currently ambiguously declared as being simply an array.

This PR declares the individual items of the returned array of either API as string.