### PR TITLE
Float/Integer: use correct types for doubles and int

### DIFF
--- a/app/swagger/1_definitions.yaml
+++ b/app/swagger/1_definitions.yaml
@@ -14,10 +14,10 @@ definitions:
     required: [ price, size, exchange, cond1, cond2, cond3, cond4, timestamp ]
     properties:
       price:
-        type: integer
+        type: number
+        format: double
         example: 159.59
         description: Price of the trade
-        format: double
       size:
         type: integer
         example: 20
@@ -52,10 +52,10 @@ definitions:
     required: [ askprice, asksize, askexchange, bidprice, bidsize, bidexchange, timestamp ]
     properties:
       askprice:
-        type: integer
+        type: number
+        format: double
         example: 159.59
         description: Ask Price
-        format: double
       asksize:
         type: integer
         example: 2
@@ -65,10 +65,10 @@ definitions:
         example: 11
         description: Exchange the ask happened on
       bidprice:
-        type: integer
+        type: number
+        format: double
         example: 159.45
         description: Bid Price
-        format: double
       bidsize:
         type: integer
         example: 20
@@ -111,10 +111,10 @@ definitions:
         example: 12
         description: The exchange this trade happened on
       price:
-        type: integer
+        type: number
+        format: double
         example: 172.17
         description: Price of the trade
-        format: double
       size:
         type: integer
         example: 50
@@ -141,15 +141,15 @@ definitions:
         example: 12
         description: Ask Exchange
       aP:
-        type: integer
+        type: number
+        format: double
         example: 173.15
         description: Ask Price
-        format: "double"
       bP:
-        type: integer
+        type: number
+        format: double
         example: 173.13
         description: Bid Price
-        format: "double"
       bS:
         type: integer
         example: 25
@@ -168,22 +168,22 @@ definitions:
     required: [ o, c, l, h, v, k, t ]
     properties:
       o:
-        type: integer
+        type: number
         format: double
         example: 173.15
         description: Open price
       c:
-        type: integer
+        type: number
         format: double
         example: 173.20
         description: Close price
       l:
-        type: integer
+        type: number
         format: double
         example: 173.15
         description: Low price
       h:
-        type: integer
+        type: number
         format: double
         example: 173.21
         description: High price
@@ -239,7 +239,7 @@ definitions:
         example: HWUPKR0MPOU8FGXBT394
         description: Legal Entity Identifier (LEI) guid for symbol ( https://en.wikipedia.org/wiki/Legal_Entity_Identifier )
       sic:
-        type: number
+        type: integer
         example: 3571
         description: Standard Industrial Classification (SIC) id for symbol ( https://en.wikipedia.org/wiki/Standard_Industrial_Classification )
       country:
@@ -255,11 +255,11 @@ definitions:
         example: Technology
         description: Sector of the indsutry in which this symbol operates in
       marketcap:
-        type: number
+        type: integer
         example: 815604985500
         description: Current market cap for this company
       employees:
-        type: number
+        type: integer
         example: 116000
         description: Approximate number of employees
       phone:
@@ -479,7 +479,7 @@ definitions:
         type: string
         example: AMC
       numberOfEstimates:
-        type: number
+        type: integer
         example: 9
       EPSSurpriseDollar:
         type: number
@@ -516,58 +516,58 @@ definitions:
         example: "2017-12-31"
         description: Report date as non date format
       grossProfit:
-        type: number
+        type: integer
         example: 33912000000
       costOfRevenue:
-        type: number
+        type: integer
         example: 54381000000
       operatingRevenue:
-        type: number
+        type: integer
         example: 88293000000
       totalRevenue:
-        type: number
+        type: integer
         example: 88293000000
       operatingIncome:
-        type: number
+        type: integer
         example: 26274000000
       netIncome:
-        type: number
+        type: integer
         example: 20065000000
       researchAndDevelopment:
-        type: number
+        type: integer
         example: 3407000000
       operatingExpense:
-        type: number
+        type: integer
         example: 7638000000
       currentAssets:
-        type: number
+        type: integer
         example: 143810000000
       totalAssets:
-        type: number
+        type: integer
         example: 406794000000
       totalLiabilities:
-        type: number
+        type: integer
         example: 266595000000
       currentCash:
-        type: number
+        type: integer
         example: 27491000000
       currentDebt:
-        type: number
+        type: integer
         example: 18478000000
       totalCash:
-        type: number
+        type: integer
         example: 77153000000
       totalDebt:
-        type: number
+        type: integer
         example: 122400000000
       shareholderEquity:
-        type: number
+        type: integer
         example: 140199000000
       cashChange:
-        type: number
+        type: integer
         example: 7202000000
       cashFlow:
-        type: number
+        type: integer
         example: 28293000000
       operatingGainsLosses:
         type: number

--- a/app/swagger/1_definitions_crypto.yaml
+++ b/app/swagger/1_definitions_crypto.yaml
@@ -8,12 +8,12 @@
     required: [ price, size, exchange, conditions, timestamp ]
     properties:
       price:
-        type: integer
+        type: number
         format: double
         example: 9349.44
         description: Trade Price
       size:
-        type: integer
+        type: number
         format: double
         example: 0.03
         description: Size of the trade
@@ -39,12 +39,12 @@
     required: [ p, s, x, c, t ]
     properties:
       p:
-        type: integer
+        type: number
         format: double
         example: 9349.44
         description: Trade Price
       s:
-        type: integer
+        type: number
         format: double
         example: 0.03
         description: Size of the trade
@@ -70,7 +70,7 @@
     required: [ id, type, market, name, url ]
     properties:
       id:
-        type: number
+        type: integer
         example: 2
         description: ID of the exchange
       type:
@@ -116,12 +116,12 @@
       prevDay:
         $ref: "#/definitions/CryptoSnapshotAgg"
       todaysChange:
-        type: integer
+        type: number
         format: double
         example: .001
         description: Value of the change from previous day
       todaysChangePerc:
-        type: integer
+        type: number
         format: double
         example: 2.55
         description: Percentage change since previous day
@@ -138,7 +138,7 @@
     required: [ p, x ]
     properties:
       p:
-        type: integer
+        type: number
         format: double
         example: 0.2907
         description: Price of this book level
@@ -171,17 +171,17 @@
         items:
           $ref: "#/definitions/CryptoSnapshotBookItem"
       bidCount:
-        type: integer
+        type: number
         format: double
         example: 1242.001
         description: Combined total number of bids in the book
       askCount:
-        type: integer
+        type: number
         format: double
         example: 1242.001
         description: Combined total number of asks in the book
       spread:
-        type: integer
+        type: number
         format: double
         example: .001
         description: Difference between the best bid and the best ask price accross exchanges
@@ -199,27 +199,27 @@
     required: [ c, h, l, o, v ]
     properties:
       c:
-        type: integer
+        type: number
         format: double
         example: 0.2907
         description: Close price
       h:
-        type: integer
+        type: number
         format: double
         example: 0.2947
         description: High price
       l:
-        type: integer
+        type: number
         format: double
         example: 0.2901
         description: Low price
       o:
-        type: integer
+        type: number
         format: double
         example: 0.2905
         description: Open price
       v:
-        type: integer
+        type: number
         format: double
         example: 1432.2907
         description: Volume

--- a/app/swagger/1_definitions_forex.yaml
+++ b/app/swagger/1_definitions_forex.yaml
@@ -5,12 +5,12 @@
     required: [ a, b, t ]
     properties:
       a:
-        type: integer
+        type: number
         format: double
         example: 0.80392
         description: Ask price
       b:
-        type: integer
+        type: number
         format: double
         example: 0.80392
         description: Bid price
@@ -26,9 +26,9 @@
     required: [ price, exchange, timestamp ]
     properties:
       price:
-        type: integer
-        example: 0.78131
+        type: number
         format: double
+        example: 0.78131
         description: Price of the trade
       exchange:
         type: integer
@@ -45,15 +45,15 @@
     required: [ ask, bid, exchange, timestamp ]
     properties:
       ask:
-        type: integer
+        type: number
+        format: double
         example: 0.7817
         description: Ask Price
-        format: double
       bid:
-        type: integer
+        type: number
+        format: double
         example: 0.78154
         description: Bid Price
-        format: double
       exchange:
         type: integer
         example: 20
@@ -68,22 +68,22 @@
     required: [ o, c, l, h, v, t ]
     properties:
       o:
-        type: integer
+        type: number
         format: double
         example: 0.81151
         description: Open price
       c:
-        type: integer
+        type: number
         format: double
         example: 0.81287
         description: Close price
       l:
-        type: integer
+        type: number
         format: double
         example: 0.81
         description: Low price
       h:
-        type: integer
+        type: number
         format: double
         example: 0.8141
         description: High price
@@ -116,12 +116,12 @@
       prevDay:
         $ref: "#/definitions/ForexSnapshotAgg"
       todaysChange:
-        type: integer
+        type: number
         format: double
         example: .001
         description: Value of the change from previous day
       todaysChangePerc:
-        type: integer
+        type: number
         format: double
         example: 2.55
         description: Percentage change since previous day
@@ -139,27 +139,27 @@
     required: [ c, h, l, o, v ]
     properties:
       c:
-        type: integer
+        type: number
         format: double
         example: 0.2907
         description: Close price
       h:
-        type: integer
+        type: number
         format: double
         example: 0.2947
         description: High price
       l:
-        type: integer
+        type: number
         format: double
         example: 0.2901
         description: Low price
       o:
-        type: integer
+        type: number
         format: double
         example: 0.2905
         description: Open price
       v:
-        type: integer
+        type: number
         example: 1432.2907
         description: Volume
 

--- a/app/swagger/1_definitions_ref.yaml
+++ b/app/swagger/1_definitions_ref.yaml
@@ -1,7 +1,3 @@
-
-
-
-
   Ticker:
     type: object
     required: [ ticker, name, market, locale, updated ]
@@ -111,12 +107,12 @@
           <br/>
           For example: Split ratio of .5 = 2 for 1 split.
       tofactor:
-        type: number
+        type: integer
         example: 7
         description: |
           To factor of the split. Used to calculate the split ratio forfactor/tofactor = ratio (eg ½ = 0.5)
       forfactor:
-        type: number
+        type: integer
         example: 1
         description: |
           For factor of the split. Used to calculate the split ratio forfactor/tofactor = ratio (eg ½ = 0.5)
@@ -146,215 +142,235 @@
         type: string
         format: date-time
         example: "1999-03-28"
-      accumulatedOtherComprehensiveIncome: 
+      accumulatedOtherComprehensiveIncome:
         type: integer
-      assets: 
+      assets:
         type: integer
-      assetsAverage: 
+      assetsAverage:
         type: integer
-      assetsCurrent: 
+      assetsCurrent:
         type: integer
-      assetTurnover: 
+      assetTurnover:
         type: integer
-      assetsNonCurrent: 
+      assetsNonCurrent:
         type: integer
-      bookValuePerShare: 
+      bookValuePerShare:
+        type: number
+        format: double
+      capitalExpenditure:
         type: integer
-      capitalExpenditure: 
+      cashAndEquivalents:
         type: integer
-      cashAndEquivalents: 
+      cashAndEquivalentsUSD:
         type: integer
-      cashAndEquivalentsUSD: 
+      costOfRevenue:
         type: integer
-      costOfRevenue: 
+      consolidatedIncome:
         type: integer
-      consolidatedIncome: 
+      currentRatio:
+        type: number
+        format: double
+      debtToEquityRatio:
+        type: number
+        format: double
+      debt:
         type: integer
-      currentRatio: 
+      debtCurrent:
         type: integer
-      debtToEquityRatio: 
+      debtNonCurrent:
         type: integer
-      debt: 
+      debtUSD:
         type: integer
-      debtCurrent: 
+      deferredRevenue:
         type: integer
-      debtNonCurrent: 
+      depreciationAmortizationAndAccretion:
         type: integer
-      debtUSD: 
+      deposits:
         type: integer
-      deferredRevenue: 
+      dividendYield:
         type: integer
-      depreciationAmortizationAndAccretion: 
+      dividendsPerBasicCommonShare:
         type: integer
-      deposits: 
+      earningBeforeInterestTaxes:
         type: integer
-      dividendYield: 
+      earningsBeforeInterestTaxesDepreciationAmortization:
         type: integer
-      dividendsPerBasicCommonShare: 
+      EBITDAMargin:
+        type: number
+        format: double
+      earningsBeforeInterestTaxesDepreciationAmortizationUSD:
         type: integer
-      earningBeforeInterestTaxes: 
+      earningBeforeInterestTaxesUSD:
         type: integer
-      earningsBeforeInterestTaxesDepreciationAmortization: 
+      earningsBeforeTax:
         type: integer
-      EBITDAMargin: 
+      earningsPerBasicShare:
+        type: number
+        format: double
+      earningsPerDilutedShare:
+        type: number
+        format: double
+      earningsPerBasicShareUSD:
+        type: number
+        format: double
+      shareholdersEquity:
         type: integer
-      earningsBeforeInterestTaxesDepreciationAmortizationUSD: 
+      averageEquity:
         type: integer
-      earningBeforeInterestTaxesUSD: 
+      shareholdersEquityUSD:
         type: integer
-      earningsBeforeTax: 
+      enterpriseValue:
         type: integer
-      earningsPerBasicShare: 
+      enterpriseValueOverEBIT:
         type: integer
-      earningsPerDilutedShare: 
+      enterpriseValueOverEBITDA:
+        type: number
+        format: double
+      freeCashFlow:
         type: integer
-      earningsPerBasicShareUSD: 
+      freeCashFlowPerShare:
+        type: number
+        format: double
+      foreignCurrencyUSDExchangeRate:
         type: integer
-      shareholdersEquity: 
+      grossProfit:
         type: integer
-      averageEquity: 
+      grossMargin:
+        type: number
+        format: double
+      goodwillAndIntangibleAssets:
         type: integer
-      shareholdersEquityUSD: 
+      interestExpense:
         type: integer
-      enterpriseValue: 
+      investedCapital:
         type: integer
-      enterpriseValueOverEBIT: 
+      investedCapitalAverage:
         type: integer
-      enterpriseValueOverEBITDA: 
+      inventory:
         type: integer
-      freeCashFlow: 
+      investments:
         type: integer
-      freeCashFlowPerShare: 
+      investmentsCurrent:
         type: integer
-      foreignCurrencyUSDExchangeRate: 
+      investmentsNonCurrent:
         type: integer
-      grossProfit: 
+      totalLiabilities:
         type: integer
-      grossMargin: 
+      currentLiabilities:
         type: integer
-      goodwillAndIntangibleAssets: 
+      liabilitiesNonCurrent:
         type: integer
-      interestExpense: 
+      marketCapitalization:
         type: integer
-      investedCapital: 
+      netCashFlow:
         type: integer
-      investedCapitalAverage: 
+      netCashFlowBusinessAcquisitionsDisposals:
         type: integer
-      inventory: 
+      issuanceEquityShares:
         type: integer
-      investments: 
+      issuanceDebtSecurities:
         type: integer
-      investmentsCurrent: 
+      paymentDividendsOtherCashDistributions:
         type: integer
-      investmentsNonCurrent: 
+      netCashFlowFromFinancing:
         type: integer
-      totalLiabilities: 
+      netCashFlowFromInvesting:
         type: integer
-      currentLiabilities: 
+      netCashFlowInvestmentAcquisitionsDisposals:
         type: integer
-      liabilitiesNonCurrent: 
+      netCashFlowFromOperations:
         type: integer
-      marketCapitalization: 
+      effectOfExchangeRateChangesOnCash:
         type: integer
-      netCashFlow: 
+      netIncome:
         type: integer
-      netCashFlowBusinessAcquisitionsDisposals: 
+      netIncomeCommonStock:
         type: integer
-      issuanceEquityShares: 
+      netIncomeCommonStockUSD:
         type: integer
-      issuanceDebtSecurities: 
+      netLossIncomeFromDiscontinuedOperations:
         type: integer
-      paymentDividendsOtherCashDistributions: 
+      netIncomeToNonControllingInterests:
         type: integer
-      netCashFlowFromFinancing: 
+      profitMargin:
+        type: number
+        format: double
+      operatingExpenses:
         type: integer
-      netCashFlowFromInvesting: 
+      operatingIncome:
         type: integer
-      netCashFlowInvestmentAcquisitionsDisposals: 
+      tradeAndNonTradePayables:
         type: integer
-      netCashFlowFromOperations: 
+      payoutRatio:
         type: integer
-      effectOfExchangeRateChangesOnCash: 
+      priceToBookValue:
+        type: number
+        format: double
+      priceEarnings:
+        type: number
+        format: double
+      priceToEarningsRatio:
+        type: number
+        format: double
+      propertyPlantEquipmentNet:
         type: integer
-      netIncome: 
+      preferredDividendsIncomeStatementImpact:
         type: integer
-      netIncomeCommonStock: 
+      sharePriceAdjustedClose:
+        type: number
+        format: double
+      priceSales:
+        type: number
+        format: double
+      priceToSalesRatio:
+        type: number
+        format: double
+      tradeAndNonTradeReceivables:
         type: integer
-      netIncomeCommonStockUSD: 
+      accumulatedRetainedEarningsDeficit:
         type: integer
-      netLossIncomeFromDiscontinuedOperations: 
+      revenues:
         type: integer
-      netIncomeToNonControllingInterests: 
+      revenuesUSD:
         type: integer
-      profitMargin: 
+      researchAndDevelopmentExpense:
         type: integer
-      operatingExpenses: 
+      returnOnAverageAssets:
         type: integer
-      operatingIncome: 
+      returnOnAverageEquity:
         type: integer
-      tradeAndNonTradePayables: 
+      returnOnInvestedCapital:
         type: integer
-      payoutRatio: 
+      returnOnSales:
+        type: number
+        format: double
+      shareBasedCompensation:
         type: integer
-      priceToBookValue: 
+      sellingGeneralAndAdministrativeExpense:
         type: integer
-      priceEarnings: 
+      shareFactor:
         type: integer
-      priceToEarningsRatio: 
+      shares:
         type: integer
-      propertyPlantEquipmentNet: 
+      weightedAverageShares:
         type: integer
-      preferredDividendsIncomeStatementImpact: 
+      weightedAverageSharesDiluted:
         type: integer
-      sharePriceAdjustedClose: 
+      salesPerShare:
+        type: number
+        format: double
+      tangibleAssetValue:
         type: integer
-      priceSales: 
+      taxAssets:
         type: integer
-      priceToSalesRatio: 
+      incomeTaxExpense:
         type: integer
-      tradeAndNonTradeReceivables: 
+      taxLiabilities:
         type: integer
-      accumulatedRetainedEarningsDeficit: 
-        type: integer
-      revenues: 
-        type: integer
-      revenuesUSD: 
-        type: integer
-      researchAndDevelopmentExpense: 
-        type: integer
-      returnOnAverageAssets: 
-        type: integer
-      returnOnAverageEquity: 
-        type: integer
-      returnOnInvestedCapital: 
-        type: integer
-      returnOnSales: 
-        type: integer
-      shareBasedCompensation: 
-        type: integer
-      sellingGeneralAndAdministrativeExpense: 
-        type: integer
-      shareFactor: 
-        type: integer
-      shares: 
-        type: integer
-      weightedAverageShares: 
-        type: integer
-      weightedAverageSharesDiluted: 
-        type: integer
-      salesPerShare: 
-        type: integer
-      tangibleAssetValue: 
-        type: integer
-      taxAssets: 
-        type: integer
-      incomeTaxExpense: 
-        type: integer
-      taxLiabilities: 
-        type: integer
-      tangibleAssetsBookValuePerShare: 
-        type: integer
-      workingCapital: 
+      tangibleAssetsBookValuePerShare:
+        type: number
+        format: double
+      workingCapital:
         type: integer
 
 

--- a/app/swagger/1_definitions_stocks.yaml
+++ b/app/swagger/1_definitions_stocks.yaml
@@ -25,10 +25,10 @@
         example: 12
         description: The exchange this trade happened on
       p:
-        type: integer
+        type: number
+        format: double
         example: 172.17
         description: Price of the trade
-        format: double
       s:
         type: integer
         example: 50
@@ -68,12 +68,12 @@
       prevDay:
         $ref: "#/definitions/StocksSnapshotAgg"
       todaysChange:
-        type: integer
+        type: number
         format: double
         example: .001
         description: Value of the change from previous day
       todaysChangePerc:
-        type: integer
+        type: number
         format: double
         example: 2.55
         description: Percentage change since previous day
@@ -90,7 +90,7 @@
     required: [ p, x ]
     properties:
       p:
-        type: integer
+        type: number
         format: double
         example: 0.2907
         description: Price of this book level
@@ -121,22 +121,22 @@
         example: "NVDA"
         description: Ticker symbol requested
       open:
-        type: integer
+        type: number
         format: double
         example: 352.89
         description: Official open price
       high:
-        type: integer
+        type: number
         format: double
         example: 352.89
         description: Official high price
       low:
-        type: integer
+        type: number
         format: double
         example: 352.89
         description: Official low price
       close:
-        type: integer
+        type: number
         format: double
         example: 352.89
         description: Official close price
@@ -149,7 +149,7 @@
         example: 355
         description: Open price in pre-market trading
       afterHours:
-        type: integer
+        type: number
         format: double
         example: 350.24
         description: Close price after hours trading
@@ -177,17 +177,17 @@
         items:
           $ref: "#/definitions/StocksSnapshotBookItem"
       bidCount:
-        type: integer
+        type: number
         format: double
         example: 1242.001
         description: Combined total number of bids in the book
       askCount:
-        type: integer
+        type: number
         format: double
         example: 1242.001
         description: Combined total number of asks in the book
       spread:
-        type: integer
+        type: number
         format: double
         example: .001
         description: Difference between the best bid and the best ask price accross exchanges
@@ -243,7 +243,7 @@
           description: Condition code
           example: 14
       p:
-        type: integer
+        type: number
         format: double
         example: 223.001
         description: Price of the trade
@@ -296,7 +296,7 @@
           example: 2
       
       p:
-        type: integer
+        type: number
         format: double
         example: 223.001
         description: BID Price
@@ -310,7 +310,7 @@
         description: BID Size ( In round lots )
       
       P:
-        type: integer
+        type: number
         format: double
         example: 223.001
         description: ASK Price
@@ -339,22 +339,22 @@
     required: [ c, h, l, o, v ]
     properties:
       c:
-        type: integer
+        type: number
         format: double
         example: 0.2907
         description: Close price
       h:
-        type: integer
+        type: number
         format: double
         example: 0.2947
         description: High price
       l:
-        type: integer
+        type: number
         format: double
         example: 0.2901
         description: Low price
       o:
-        type: integer
+        type: number
         format: double
         example: 0.2905
         description: Open price
@@ -370,7 +370,7 @@
     required: [ p, s, P, S, t ]
     properties:
       p:
-        type: integer
+        type: number
         format: double
         example: 120.00
         description: Bid Price
@@ -379,7 +379,7 @@
         example: 5
         description: Bid size in lots
       P:
-        type: integer
+        type: number
         format: double
         example: 121.00
         description: Ask Price
@@ -407,27 +407,27 @@
         description: Volume
         example: 31315282
       o:
-        type: integer
+        type: number
         format: double
         description: Open
         example: 102.87
       c:
-        type: integer
+        type: number
         format: double
         description: Close
         example: 103.74
       h:
-        type: integer
+        type: number
         format: double
         description: High
         example: 103.82
       l:
-        type: integer
+        type: number
         format: double
         description: Low
         example: 102.65
       t:
-        type: number
+        type: integer
         description: Unix Msec Timestamp ( Start of Aggregate window )
         example: 1549314000000
       "n":
@@ -456,11 +456,11 @@
         description: If this response was adjusted for splits
         example: true
       queryCount:
-        type: number
-        description: Number of aggregate ( min or day ) used to generate the response
+        type: integer
+        description: Number of aggregate (min or day) used to generate the response
         example: 55
       resultsCount:
-        type: number
+        type: integer
         description: Total number of results generated
         example: 2
       results:

--- a/app/swagger/3_reference.yaml
+++ b/app/swagger/3_reference.yaml
@@ -67,7 +67,7 @@
           description: |
             How many items to be on each page during pagination. Max 50
           required: false
-          type: number
+          type: integer
           default: 50
         - name: page
           in: query
@@ -75,7 +75,7 @@
             Which page of results to return
           required: false
           default: 1
-          type: number
+          type: integer
         - name: active
           in: query
           description: |
@@ -217,7 +217,7 @@
           description: |
             How many items to be on each page during pagination. Max 50
           required: false
-          type: number
+          type: integer
           default: 50
         - name: page
           in: query
@@ -225,7 +225,7 @@
             Which page of results to return
           required: false
           default: 1
-          type: number
+          type: integer
       tags:
         - Reference
       responses:
@@ -347,7 +347,7 @@
                 type: string
                 example: OK
               count: 
-                type: number
+                type: integer
                 example: 1
               results:
                 type: array
@@ -387,7 +387,7 @@
                 type: string
                 example: OK
               count: 
-                type: number
+                type: integer
                 example: 1
               results:
                 type: array
@@ -422,7 +422,7 @@
             Limit the number of results
           required: false
           default: 5
-          type: number
+          type: integer
         - name: type
           in: query
           description: |
@@ -449,7 +449,7 @@
                 type: string
                 example: OK
               count: 
-                type: number
+                type: integer
                 example: 1
               results:
                 type: array

--- a/app/swagger/41_stocks.yaml
+++ b/app/swagger/41_stocks.yaml
@@ -157,7 +157,7 @@
         in: path
         description: Size of the timespan multiplier
         required: true
-        type: number
+        type: integer
         default: 1
       - name: timespan
         in: path

--- a/app/swagger/4_crypto.yaml
+++ b/app/swagger/4_crypto.yaml
@@ -79,12 +79,12 @@
                 type: object
                 properties:
                   avg:
-                    type: int
+                    type: number
                     format: double
                     description: Average of the trades analyzed
                     example: 9348.727
                   tradesAveraged:
-                    type: int
+                    type: integer
                     description: Number of trades that were analyzed to get the average.
                     example: 10
         default:
@@ -141,12 +141,12 @@
                 format: date
                 example: 2018-5-9
               open:
-                type: int
+                type: number
                 format: double
                 description: Opening trade price
                 example: 9228.1801
               close:
-                type: int
+                type: number
                 format: double
                 description: Closing trade price
                 example: 9300.40000001


### PR DESCRIPTION
The OpenAPI specification allows numbers to be declared as either of two types, with three variants each.

Integers cannot be used to describe floats and doubles, and conformant implementations will drop the fractional-part.

Similarly, doubles cannot be used to describe int64 values as their precision is truncated to 53 bit when conformant implementations reserve one bit for sign and 10 bit for the exponent of the double.

As part of the ongoing process of building the Rust integration, I have tested most data endpoints and found many incorrectly declared fields.

In this PR,

- fields incorrectly typed as float with double format while being an integer are changed to integer type,
- fields incorrectly typed as integer while representing a double are changed to float type with double format,
- fields correctly typed as float while not explicitly representing a double format are changed to float type with double format,
- fields unneccessarily limiting the precision of floats by declaring them as 32bit floats are changed to float type with double format.